### PR TITLE
hp2any-graph should update the window without needing user interaction

### DIFF
--- a/graph/src/Graph.hs
+++ b/graph/src/Graph.hs
@@ -106,6 +106,13 @@ main = withSocketsDo $ do
     matrixMode $= Modelview 0
     postRedisplay Nothing
 
+  -- Since we are using the non-threaded rts, Haskell threads other than
+  -- the main thread will never run unless a callback is invoked. The timer
+  -- callback below eusures that this happens regularly.
+  let registerTimer = addTimerCallback timeoutMilliseconds registerTimer
+      timeoutMilliseconds = 50
+  registerTimer
+
   -- If the mouse is moved, we find out which cost centre it is
   -- hovering over, and refresh the display if there is a change.
   passiveMotionCallback $== \pos -> glProtect $ do


### PR DESCRIPTION
Currently hp2any-graph updates the window only when it receives a window system event like mouse moving. This is inconvenient because you need to keep moving your mouse or keep a key pressed to get the window updated real time.
