### PR TITLE
Embed the manager.glade file and put it in a temporary file on start.

### DIFF
--- a/manager/hp2any-manager.cabal
+++ b/manager/hp2any-manager.cabal
@@ -27,9 +27,22 @@ Executable hp2any-manager
   other-modules:  Paths_hp2any_manager
   HS-Source-Dirs: src
   Main-IS:        Manager.hs
-  Build-Depends:  base >= 4 && < 5, containers, array, filepath, directory, time,
-                  glib, gtk, gtkglext, glade, cairo, OpenGL,
-                  bytestring, hp2any-core, hp2any-graph
+  Build-Depends:  base >= 4 && < 5,
+                  containers,
+                  array,
+                  filepath,
+                  file-embed,
+                  directory,
+                  time,
+                  glib,
+                  gtk,
+                  gtkglext,
+                  glade,
+                  cairo,
+                  OpenGL,
+                  bytestring,
+                  hp2any-core,
+                  hp2any-graph
   GHC-Options:    -Wall -O2
 
 source-repository head

--- a/manager/src/Manager.hs
+++ b/manager/src/Manager.hs
@@ -236,6 +236,7 @@ makeCostCentreList prof = do
 
   Gtk.set nameColumn [ treeViewColumnTitle := ("Name" :: String)
                      , treeViewColumnExpand := True
+                     , treeViewColumnSortColumnId := 2
                      ]
 
   Gtk.set costColumn [ treeViewColumnTitle := ("Total cost" :: String)
@@ -245,6 +246,10 @@ makeCostCentreList prof = do
   treeSortableSetSortFunc sortable 1 $ \i1 i2 ->
     compare <$> (getCost <$> treeModelGetRow model i1)
             <*> (getCost <$> treeModelGetRow model i2)
+
+  treeSortableSetSortFunc sortable 2 $ \i1 i2 ->
+    compare <$> ((dropWhile (/= ')') . getName) <$> treeModelGetRow model i1)
+            <*> ((dropWhile (/= ')') . getName) <$> treeModelGetRow model i2)
 
   cellLayoutSetAttributes nameColumn nameRender model $ \ccdat -> [cellTextMarkup := Just (getName ccdat)]
   cellLayoutSetAttributes costColumn costRender model $ \ccdat -> [cellText := showBigInteger (getCost ccdat)]

--- a/manager/src/Manager.hs
+++ b/manager/src/Manager.hs
@@ -401,10 +401,13 @@ makeGraphCanvas selectRgb prof = do
 
     (t1,t2) <- getInterval
     c <- getMaxCost
+    let asBytes :: Integer
+        asBytes = (fromIntegral h-fromIntegral y) * fromIntegral c `div` fromIntegral h
     let text :: String
-        text = printf " time=%0.2f, cost=%s "
+        text = printf " time=%0.2f sec, cost=%s bytes (%s MB)"
             (t1+eventX evt*(t2-t1)/fromIntegral w)
-            (showBigInteger ((fromIntegral h-fromIntegral y)*fromIntegral c `div` fromIntegral h :: Integer))
+            (showBigInteger asBytes)
+            (show $ (fromIntegral asBytes) / 1000000)
     labelSetText coordLabel text
 
     -- Highlighting current cost centre under the mouse.


### PR DESCRIPTION
Unfortunately, the xmlNewWithRootAndDomain function really expects a FilePath to file, so we write the embedded glade file to a temporary file and delete it when the window is destroyed.

The deletion code is naive and ignores permission issues and other exceptions. In the event of trouble, we might want to update this to handle those.

Also includes the changes from https://github.com/cobbpg/hp2any/pull/13.